### PR TITLE
add ruby example

### DIFF
--- a/ruby/requests_proxy.rb
+++ b/ruby/requests_proxy.rb
@@ -1,0 +1,16 @@
+require 'net/http'
+require 'uri'
+
+uri = URI('http://example.com')
+proxy_uri = URI('http://host:port')
+proxy_options = {
+  p_addr: proxy_options.host,
+  p_port: proxy_options.port,
+  # username/password are optional if you have IP authentication
+  p_user: 'USERNAME',
+  p_pass: 'PASSWORD',
+}
+
+Net::HTTP.start(uri.host, uri.port, **proxy_options) do |http|
+  response = http.get('/')
+end

--- a/ruby/requests_proxy.rb
+++ b/ruby/requests_proxy.rb
@@ -2,15 +2,15 @@ require 'net/http'
 require 'uri'
 
 uri = URI('http://example.com')
-proxy_uri = URI('http://host:port')
 proxy_options = {
-  p_addr: proxy_options.host,
-  p_port: proxy_options.port,
+  p_addr: 'PROXYHOST',
+  p_port: PORT,
   # username/password are optional if you have IP authentication
   p_user: 'USERNAME',
   p_pass: 'PASSWORD',
 }
 
 Net::HTTP.start(uri.host, uri.port, **proxy_options) do |http|
-  response = http.get('/')
+  request = Net::HTTP::Get.new uri
+  response = http.request request
 end


### PR DESCRIPTION
Added a ruby example for doing a http request using a proxy using Ruby's Net::HTTP class.

Closes #1 