### PR TITLE
ci: add proxy integration tests workflow

### DIFF
--- a/.github/workflows/proxy_integration_tests.yml
+++ b/.github/workflows/proxy_integration_tests.yml
@@ -1,0 +1,47 @@
+# Integration tests against a real proxy (PROXY_URL). Add repository secret PROXY_URL
+# under Settings → Secrets and variables → Actions, then mark this workflow as a required
+# status check under branch protection (pull_request events only receive secrets for PRs
+# from the same repository, not from forks).
+
+name: Proxy integration tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: javascript/package-lock.json
+
+      - name: Install dependencies
+        working-directory: javascript
+        run: npm ci
+
+      - name: Require PROXY_URL Actions secret
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: |
+          if [ -z "${PROXY_URL}" ]; then
+            echo "::error::PROXY_URL is not set. Add a repository (or environment) secret named PROXY_URL under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+      - name: Run integration tests
+        working-directory: javascript
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: npm test

--- a/.github/workflows/proxy_integration_tests_javascript.yml
+++ b/.github/workflows/proxy_integration_tests_javascript.yml
@@ -3,10 +3,13 @@
 # status check under branch protection (pull_request events only receive secrets for PRs
 # from the same repository, not from forks).
 
-name: Proxy integration tests
+name: Proxy integration tests (JavaScript)
 
 on:
   pull_request:
+    paths:
+      - "javascript/**"
+      - ".github/workflows/proxy_integration_tests_javascript.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/proxy_integration_tests_php.yml
+++ b/.github/workflows/proxy_integration_tests_php.yml
@@ -1,0 +1,50 @@
+# Integration tests against a real proxy (PROXY_URL). Add repository secret PROXY_URL
+# under Settings → Secrets and variables → Actions, then mark this workflow as a required
+# status check under branch protection (pull_request events only receive secrets for PRs
+# from the same repository, not from forks).
+
+name: Proxy integration tests (PHP)
+
+on:
+  pull_request:
+    paths:
+      - "php/**"
+      - ".github/workflows/proxy_integration_tests_php.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          extensions: curl
+          coverage: none
+
+      - name: Install Composer dependencies
+        working-directory: php
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Require PROXY_URL Actions secret
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: |
+          if [ -z "${PROXY_URL}" ]; then
+            echo "::error::PROXY_URL is not set. Add a repository (or environment) secret named PROXY_URL under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+      - name: Run integration tests
+        working-directory: php
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: php run_tests.php

--- a/.github/workflows/proxy_integration_tests_python.yml
+++ b/.github/workflows/proxy_integration_tests_python.yml
@@ -1,0 +1,52 @@
+# Integration tests against a real proxy (PROXY_URL). Add repository secret PROXY_URL
+# under Settings → Secrets and variables → Actions, then mark this workflow as a required
+# status check under branch protection (pull_request events only receive secrets for PRs
+# from the same repository, not from forks).
+
+name: Proxy integration tests (Python)
+
+on:
+  pull_request:
+    paths:
+      - "python/**"
+      - ".github/workflows/proxy_integration_tests_python.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install system dependencies (pycurl)
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Install python-proxy-headers and example dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install python-proxy-headers requests urllib3 aiohttp httpx cloudscraper autoscraper pycurl
+
+      - name: Require PROXY_URL Actions secret
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: |
+          if [ -z "${PROXY_URL}" ]; then
+            echo "::error::PROXY_URL is not set. Add a repository (or environment) secret named PROXY_URL under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+      - name: Run integration tests
+        working-directory: python
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: python run_tests.py

--- a/.github/workflows/proxy_integration_tests_ruby.yml
+++ b/.github/workflows/proxy_integration_tests_ruby.yml
@@ -1,0 +1,46 @@
+# Integration tests against a real proxy (PROXY_URL). Add repository secret PROXY_URL
+# under Settings → Secrets and variables → Actions, then mark this workflow as a required
+# status check under branch protection (pull_request events only receive secrets for PRs
+# from the same repository, not from forks).
+
+name: Proxy integration tests (Ruby)
+
+on:
+  pull_request:
+    paths:
+      - "ruby/**"
+      - ".github/workflows/proxy_integration_tests_ruby.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@2e007403fc1ec238429ecaa57af6f22f019cc135 # v1.234.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: ruby
+
+      - name: Require PROXY_URL Actions secret
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: |
+          if [ -z "${PROXY_URL}" ]; then
+            echo "::error::PROXY_URL is not set. Add a repository (or environment) secret named PROXY_URL under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
+      - name: Run integration tests
+        working-directory: ruby
+        env:
+          PROXY_URL: ${{ secrets.PROXY_URL }}
+        run: bundle exec ruby run_tests.rb


### PR DESCRIPTION
Adds a GitHub Actions workflow (same pattern as [ruby-proxy-headers](https://github.com/proxymesh/ruby-proxy-headers/blob/main/.github/workflows/proxy_integration_tests.yml)) that runs integration tests against a real proxy when `PROXY_URL` is configured as a repository Actions secret.

**Setup after merge:** add the `PROXY_URL` secret under **Settings → Secrets and variables → Actions**, and optionally require the **Proxy integration tests** check in branch protection for PRs from this repo (fork PRs do not receive secrets).

Made with [Cursor](https://cursor.com)