### PR TITLE
Add Dependabot auto-approve/auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot_auto_approve_merge.yml
+++ b/.github/workflows/dependabot_auto_approve_merge.yml
@@ -1,0 +1,46 @@
+# Approve Dependabot pull requests and enable auto-merge so GitHub merges them once
+# required status checks pass. Enable "Allow auto-merge" under Settings → General →
+# Pull Requests, and require status checks on the default branch. See:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+
+name: Dependabot auto-approve and merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve pull request
+        run: |
+          set -euo pipefail
+          if [ "$(gh pr view "${PR_NUMBER}" --json reviewDecision -q .reviewDecision)" != "APPROVED" ]; then
+            gh pr review --approve "${PR_NUMBER}"
+          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: |
+          set -euo pipefail
+          if [ "$(gh pr view "${PR_NUMBER}" --json autoMergeRequest -q '.autoMergeRequest != null')" != "true" ]; then
+            gh pr merge --auto --merge "${PR_NUMBER}"
+          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/proxy_integration_tests_javascript.yml
+++ b/.github/workflows/proxy_integration_tests_javascript.yml
@@ -10,9 +10,26 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect JavaScript changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        with:
+          filters: |
+            relevant:
+              - "javascript/**"
+              - ".github/workflows/proxy_integration_tests_javascript.yml"
+
   integration:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -20,23 +37,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Detect JavaScript changes
-        id: changes
-        run: |
-          set -euo pipefail
-          changed="false"
-          while IFS= read -r file; do
-            case "${file}" in
-              javascript/*|.github/workflows/proxy_integration_tests_javascript.yml)
-                changed="true"
-                break
-                ;;
-            esac
-          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
-          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
-
       - name: Set up Node
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 (Node 24)
         with:
           node-version: "24"
@@ -44,12 +45,10 @@ jobs:
           cache-dependency-path: javascript/package-lock.json
 
       - name: Install dependencies
-        if: steps.changes.outputs.changed == 'true'
         working-directory: javascript
         run: npm ci
 
       - name: Require PROXY_URL Actions secret
-        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -59,12 +58,7 @@ jobs:
           fi
 
       - name: Run integration tests
-        if: steps.changes.outputs.changed == 'true'
         working-directory: javascript
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: npm test
-
-      - name: Skip when JavaScript files are unchanged
-        if: steps.changes.outputs.changed != 'true'
-        run: echo "No JavaScript integration test changes detected; skipping."

--- a/.github/workflows/proxy_integration_tests_javascript.yml
+++ b/.github/workflows/proxy_integration_tests_javascript.yml
@@ -7,9 +7,6 @@ name: Proxy integration tests (JavaScript)
 
 on:
   pull_request:
-    paths:
-      - "javascript/**"
-      - ".github/workflows/proxy_integration_tests_javascript.yml"
 
 permissions:
   contents: read
@@ -23,7 +20,23 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Detect JavaScript changes
+        id: changes
+        run: |
+          set -euo pipefail
+          changed="false"
+          while IFS= read -r file; do
+            case "${file}" in
+              javascript/*|.github/workflows/proxy_integration_tests_javascript.yml)
+                changed="true"
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+
       - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 (Node 24)
         with:
           node-version: "24"
@@ -31,10 +44,12 @@ jobs:
           cache-dependency-path: javascript/package-lock.json
 
       - name: Install dependencies
+        if: steps.changes.outputs.changed == 'true'
         working-directory: javascript
         run: npm ci
 
       - name: Require PROXY_URL Actions secret
+        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -44,7 +59,12 @@ jobs:
           fi
 
       - name: Run integration tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: javascript
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: npm test
+
+      - name: Skip when JavaScript files are unchanged
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No JavaScript integration test changes detected; skipping."

--- a/.github/workflows/proxy_integration_tests_php.yml
+++ b/.github/workflows/proxy_integration_tests_php.yml
@@ -10,9 +10,26 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect PHP changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        with:
+          filters: |
+            relevant:
+              - "php/**"
+              - ".github/workflows/proxy_integration_tests_php.yml"
+
   integration:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -20,23 +37,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Detect PHP changes
-        id: changes
-        run: |
-          set -euo pipefail
-          changed="false"
-          while IFS= read -r file; do
-            case "${file}" in
-              php/*|.github/workflows/proxy_integration_tests_php.yml)
-                changed="true"
-                break
-                ;;
-            esac
-          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
-          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
-
       - name: Set up PHP
-        if: steps.changes.outputs.changed == 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.3"
@@ -44,12 +45,10 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        if: steps.changes.outputs.changed == 'true'
         working-directory: php
         run: composer install --no-interaction --prefer-dist
 
       - name: Require PROXY_URL Actions secret
-        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -59,12 +58,7 @@ jobs:
           fi
 
       - name: Run integration tests
-        if: steps.changes.outputs.changed == 'true'
         working-directory: php
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: php run_tests.php
-
-      - name: Skip when PHP files are unchanged
-        if: steps.changes.outputs.changed != 'true'
-        run: echo "No PHP integration test changes detected; skipping."

--- a/.github/workflows/proxy_integration_tests_php.yml
+++ b/.github/workflows/proxy_integration_tests_php.yml
@@ -7,9 +7,6 @@ name: Proxy integration tests (PHP)
 
 on:
   pull_request:
-    paths:
-      - "php/**"
-      - ".github/workflows/proxy_integration_tests_php.yml"
 
 permissions:
   contents: read
@@ -23,7 +20,23 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Detect PHP changes
+        id: changes
+        run: |
+          set -euo pipefail
+          changed="false"
+          while IFS= read -r file; do
+            case "${file}" in
+              php/*|.github/workflows/proxy_integration_tests_php.yml)
+                changed="true"
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+
       - name: Set up PHP
+        if: steps.changes.outputs.changed == 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.3"
@@ -31,10 +44,12 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
+        if: steps.changes.outputs.changed == 'true'
         working-directory: php
         run: composer install --no-interaction --prefer-dist
 
       - name: Require PROXY_URL Actions secret
+        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -44,7 +59,12 @@ jobs:
           fi
 
       - name: Run integration tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: php
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: php run_tests.php
+
+      - name: Skip when PHP files are unchanged
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No PHP integration test changes detected; skipping."

--- a/.github/workflows/proxy_integration_tests_python.yml
+++ b/.github/workflows/proxy_integration_tests_python.yml
@@ -10,9 +10,26 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect Python changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        with:
+          filters: |
+            relevant:
+              - "python/**"
+              - ".github/workflows/proxy_integration_tests_python.yml"
+
   integration:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -20,40 +37,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Detect Python changes
-        id: changes
-        run: |
-          set -euo pipefail
-          changed="false"
-          while IFS= read -r file; do
-            case "${file}" in
-              python/*|.github/workflows/proxy_integration_tests_python.yml)
-                changed="true"
-                break
-                ;;
-            esac
-          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
-          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
-
       - name: Set up Python
-        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0 (Node 24)
         with:
           # Pin for reproducible dependency wheels (pycurl, etc.); adjust as needed.
           python-version: "3.12"
 
       - name: Install system dependencies (pycurl)
-        if: steps.changes.outputs.changed == 'true'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Install example dependencies
-        if: steps.changes.outputs.changed == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r python/requirements.txt
 
       - name: Require PROXY_URL Actions secret
-        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -63,12 +61,7 @@ jobs:
           fi
 
       - name: Run integration tests
-        if: steps.changes.outputs.changed == 'true'
         working-directory: python
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: python run_tests.py
-
-      - name: Skip when Python files are unchanged
-        if: steps.changes.outputs.changed != 'true'
-        run: echo "No Python integration test changes detected; skipping."

--- a/.github/workflows/proxy_integration_tests_python.yml
+++ b/.github/workflows/proxy_integration_tests_python.yml
@@ -7,9 +7,6 @@ name: Proxy integration tests (Python)
 
 on:
   pull_request:
-    paths:
-      - "python/**"
-      - ".github/workflows/proxy_integration_tests_python.yml"
 
 permissions:
   contents: read
@@ -23,21 +20,40 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Detect Python changes
+        id: changes
+        run: |
+          set -euo pipefail
+          changed="false"
+          while IFS= read -r file; do
+            case "${file}" in
+              python/*|.github/workflows/proxy_integration_tests_python.yml)
+                changed="true"
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+
       - name: Set up Python
+        if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0 (Node 24)
         with:
           # Pin for reproducible dependency wheels (pycurl, etc.); adjust as needed.
           python-version: "3.12"
 
       - name: Install system dependencies (pycurl)
+        if: steps.changes.outputs.changed == 'true'
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Install example dependencies
+        if: steps.changes.outputs.changed == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r python/requirements.txt
 
       - name: Require PROXY_URL Actions secret
+        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -47,7 +63,12 @@ jobs:
           fi
 
       - name: Run integration tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: python
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: python run_tests.py
+
+      - name: Skip when Python files are unchanged
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No Python integration test changes detected; skipping."

--- a/.github/workflows/proxy_integration_tests_ruby.yml
+++ b/.github/workflows/proxy_integration_tests_ruby.yml
@@ -10,9 +10,26 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect Ruby changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        with:
+          filters: |
+            relevant:
+              - "ruby/**"
+              - ".github/workflows/proxy_integration_tests_ruby.yml"
+
   integration:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -20,23 +37,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Detect Ruby changes
-        id: changes
-        run: |
-          set -euo pipefail
-          changed="false"
-          while IFS= read -r file; do
-            case "${file}" in
-              ruby/*|.github/workflows/proxy_integration_tests_ruby.yml)
-                changed="true"
-                break
-                ;;
-            esac
-          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
-          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
-
       - name: Set up Ruby
-        if: steps.changes.outputs.changed == 'true'
         uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0 (Node 24)
         with:
           ruby-version: "3.3"
@@ -44,7 +45,6 @@ jobs:
           working-directory: ruby
 
       - name: Require PROXY_URL Actions secret
-        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -54,12 +54,7 @@ jobs:
           fi
 
       - name: Run integration tests
-        if: steps.changes.outputs.changed == 'true'
         working-directory: ruby
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: bundle exec ruby run_tests.rb
-
-      - name: Skip when Ruby files are unchanged
-        if: steps.changes.outputs.changed != 'true'
-        run: echo "No Ruby integration test changes detected; skipping."

--- a/.github/workflows/proxy_integration_tests_ruby.yml
+++ b/.github/workflows/proxy_integration_tests_ruby.yml
@@ -7,9 +7,6 @@ name: Proxy integration tests (Ruby)
 
 on:
   pull_request:
-    paths:
-      - "ruby/**"
-      - ".github/workflows/proxy_integration_tests_ruby.yml"
 
 permissions:
   contents: read
@@ -23,7 +20,23 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Detect Ruby changes
+        id: changes
+        run: |
+          set -euo pipefail
+          changed="false"
+          while IFS= read -r file; do
+            case "${file}" in
+              ruby/*|.github/workflows/proxy_integration_tests_ruby.yml)
+                changed="true"
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+
       - name: Set up Ruby
+        if: steps.changes.outputs.changed == 'true'
         uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0 (Node 24)
         with:
           ruby-version: "3.3"
@@ -31,6 +44,7 @@ jobs:
           working-directory: ruby
 
       - name: Require PROXY_URL Actions secret
+        if: steps.changes.outputs.changed == 'true'
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: |
@@ -40,7 +54,12 @@ jobs:
           fi
 
       - name: Run integration tests
+        if: steps.changes.outputs.changed == 'true'
         working-directory: ruby
         env:
           PROXY_URL: ${{ secrets.PROXY_URL }}
         run: bundle exec ruby run_tests.rb
+
+      - name: Skip when Ruby files are unchanged
+        if: steps.changes.outputs.changed != 'true'
+        run: echo "No Ruby integration test changes detected; skipping."


### PR DESCRIPTION
## Summary
- add a workflow that runs on Dependabot pull request events
- auto-approve Dependabot PRs and enable GitHub auto-merge
- keep approval/merge steps idempotent so synchronize reruns do not fail

## Test plan
- [x] run `actionlint .github/workflows/dependabot_auto_approve_merge.yml`
- [ ] open a Dependabot PR and confirm it receives approval
- [ ] verify auto-merge is enabled and merges after required checks pass