### PR TITLE
Auto-approve and merge non-major Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,9 +24,14 @@ jobs:
     steps:
       - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         id: meta
+        with:
+          # Branch updates add non-Dependabot merge commits; still parse Dependabot metadata.
+          skip-commit-verification: true
 
+      # Fail closed: only allowlisted minor/patch types. Empty/unknown update-type must not
+      # approve or merge (e.g. if metadata is missing after an unusual branch history).
       - name: Approve pull request
-        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        if: contains(fromJSON('["version-update:semver-minor","version-update:semver-patch"]'), steps.meta.outputs.update-type)
         run: |
           set -euo pipefail
           if [ "$(gh pr view "$PR" --json reviewDecision -q .reviewDecision)" != "APPROVED" ]; then
@@ -37,7 +42,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        if: contains(fromJSON('["version-update:semver-minor","version-update:semver-patch"]'), steps.meta.outputs.update-type)
         run: |
           set -euo pipefail
           if [ "$(gh pr view "$PR" --json autoMergeRequest -q '.autoMergeRequest != null')" != "true" ]; then

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,7 @@ name: dependabot-auto-merge
 
 on:
   pull_request_target:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: write
@@ -18,8 +19,11 @@ permissions:
 
 jobs:
   automerge:
-    # Key off the PR author so synchronize events from branch updates still run.
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # Same-repo Dependabot PRs only. Key off the PR author so synchronize events from
+    # branch updates (non-Dependabot merge commits) still run.
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
@@ -30,6 +34,7 @@ jobs:
 
       # Fail closed: only allowlisted minor/patch types. Empty/unknown update-type must not
       # approve or merge (e.g. if metadata is missing after an unusual branch history).
+      # Does not check out or execute PR code — only calls the GitHub API.
       - name: Approve pull request
         if: contains(fromJSON('["version-update:semver-minor","version-update:semver-patch"]'), steps.meta.outputs.update-type)
         run: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,18 +1,48 @@
+# Approve Dependabot pull requests and enable auto-merge so GitHub merges them once
+# required status checks pass. Requires:
+# - Settings → General → Pull Requests → Allow auto-merge
+# - Settings → Actions → General → Allow GitHub Actions to create and approve pull requests
+# - Branch protection required status checks (reviews are satisfied by this workflow)
+# See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
+#
+# Major version updates are left for human review (matches Dependabot grouping policy).
+
 name: dependabot-auto-merge
+
 on:
-  pull_request_target
+  pull_request_target:
+
 permissions:
   contents: write
   pull-requests: write
+
 jobs:
   automerge:
-    if: github.actor == 'dependabot[bot]'
+    # Key off the PR author so synchronize events from branch updates still run.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         id: meta
-      - if: steps.meta.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto --squash "$PR"
+
+      - name: Approve pull request
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: |
+          set -euo pipefail
+          if [ "$(gh pr view "$PR" --json reviewDecision -q .reviewDecision)" != "APPROVED" ]; then
+            gh pr review --approve "$PR"
+          fi
+        env:
+          PR: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: |
+          set -euo pipefail
+          if [ "$(gh pr view "$PR" --json autoMergeRequest -q '.autoMergeRequest != null')" != "true" ]; then
+            gh pr merge --auto --squash "$PR"
+          fi
         env:
           PR: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Dependabot PRs were enabling auto-merge but staying `BLOCKED` with `REVIEW_REQUIRED` because branch protection needs an approving review.

This updates `dependabot-auto-merge` to:
- Auto-approve non-major Dependabot PRs
- Enable squash auto-merge for those PRs
- Match on PR author (`dependabot[bot]`) instead of `github.actor`, so branch updates still trigger the workflow
- Leave major updates for human review (same policy as Dependabot grouping)
- Restrict to same-repo heads and explicit `pull_request_target` types

## Bugbot follow-up
Fail closed when `update-type` is empty/unknown (can happen after human branch updates if commit verification fails). Use `skip-commit-verification` so metadata still parses after merge commits, and only auto-approve/merge explicit `semver-minor` / `semver-patch` updates.

## Repo setting to confirm
Settings → Actions → General → **Allow GitHub Actions to create and approve pull requests** must be enabled, or the approve step will fail.

## After merge
Update open Dependabot PR branches (or `@dependabot rebase`) so they re-run against the new workflow on `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://proxymesh.slack.com/archives/C0BMTB962RE/p1788473795626639?thread_ts=1788473795.626639&cid=C0BMTB962RE)

<div><a href="https://cursor.com/agents/bc-0bbb48cb-cc5a-588d-8168-da785840c08c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bbb48cb-cc5a-588d-8168-da785840c08c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

