### PR TITLE
Fix Dependabot auto-approve when update-type is empty

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      dev-all:
+      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      dev-minor-patch:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
+      dev-major:
+        dependency-type: "development"
+        update-types:
           - "major"
 
   - package-ecosystem: "pip"
@@ -41,11 +45,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      dev-all:
+      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      dev-minor-patch:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
+      dev-major:
+        dependency-type: "development"
+        update-types:
           - "major"
 
   - package-ecosystem: "bundler"
@@ -65,11 +73,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      dev-all:
+      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      dev-minor-patch:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
+      dev-major:
+        dependency-type: "development"
+        update-types:
           - "major"
 
   - package-ecosystem: "composer"
@@ -89,11 +101,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      dev-all:
+      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      dev-minor-patch:
         dependency-type: "development"
         update-types:
           - "minor"
           - "patch"
+      dev-major:
+        dependency-type: "development"
+        update-types:
           - "major"
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,11 +32,62 @@ jobs:
           # Branch updates add non-Dependabot merge commits; still parse Dependabot metadata.
           skip-commit-verification: true
 
-      # Fail closed: only allowlisted minor/patch types. Empty/unknown update-type must not
-      # approve or merge (e.g. if metadata is missing after an unusual branch history).
-      # Does not check out or execute PR code — only calls the GitHub API.
+      # Decide eligibility without checking out PR code (GitHub API only).
+      # fetch-metadata often leaves update-type empty for pip requirement-range bumps
+      # ("Update X from >=a to >=b in /dir"), so fall back to title/group heuristics.
+      - name: Determine eligibility
+        id: eligible
+        env:
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEPENDENCY_GROUP: ${{ steps.meta.outputs.dependency-group }}
+          PR: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          allow=false
+          reason="blocked"
+
+          case "$UPDATE_TYPE" in
+            version-update:semver-major)
+              reason="major-update-type"
+              ;;
+            version-update:semver-minor|version-update:semver-patch)
+              allow=true
+              reason="update-type:$UPDATE_TYPE"
+              ;;
+            *)
+              # Empty/unknown: allow known non-major Dependabot groups.
+              case "$DEPENDENCY_GROUP" in
+                prod-minor-patch|dev-all)
+                  allow=true
+                  reason="dependency-group:$DEPENDENCY_GROUP"
+                  ;;
+                *)
+                  title="$(gh pr view "$PR" --json title -q .title)"
+                  # Match "from [>=~^]*X.Y.Z to [>=~^]*A.B.C", ignoring trailing " in /dir".
+                  if [[ "$title" =~ from[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+)[^[:space:]]*[[:space:]]+to[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+) ]]; then
+                    from_major="${BASH_REMATCH[1]}"
+                    to_major="${BASH_REMATCH[3]}"
+                    if [[ "$from_major" == "$to_major" ]]; then
+                      allow=true
+                      reason="title-non-major:$from_major->$to_major"
+                    else
+                      reason="title-major:$from_major->$to_major"
+                    fi
+                  else
+                    reason="unclassified-update-type"
+                  fi
+                  ;;
+              esac
+              ;;
+          esac
+
+          echo "eligibility allow=$allow reason=$reason update_type=${UPDATE_TYPE:-<empty>} group=${DEPENDENCY_GROUP:-<empty>}"
+          echo "allow=$allow" >> "$GITHUB_OUTPUT"
+
       - name: Approve pull request
-        if: contains(fromJSON('["version-update:semver-minor","version-update:semver-patch"]'), steps.meta.outputs.update-type)
+        if: steps.eligible.outputs.allow == 'true'
         run: |
           set -euo pipefail
           if [ "$(gh pr view "$PR" --json reviewDecision -q .reviewDecision)" != "APPROVED" ]; then
@@ -47,7 +98,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: contains(fromJSON('["version-update:semver-minor","version-update:semver-patch"]'), steps.meta.outputs.update-type)
+        if: steps.eligible.outputs.allow == 'true'
         run: |
           set -euo pipefail
           if [ "$(gh pr view "$PR" --json autoMergeRequest -q '.autoMergeRequest != null')" != "true" ]; then

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -34,7 +34,9 @@ jobs:
 
       # Decide eligibility without checking out PR code (GitHub API only).
       # fetch-metadata often leaves update-type empty for pip requirement-range bumps
-      # ("Update X from >=a to >=b in /dir"), so fall back to title/group heuristics.
+      # ("Update X from >=a to >=b in /dir"). Fall back to prod-minor-patch group
+      # membership, otherwise same-major title parsing. Never short-circuit on
+      # dev-all (that group includes majors).
       - name: Determine eligibility
         id: eligible
         env:
@@ -57,29 +59,28 @@ jobs:
               reason="update-type:$UPDATE_TYPE"
               ;;
             *)
-              # Empty/unknown: allow known non-major Dependabot groups.
-              case "$DEPENDENCY_GROUP" in
-                prod-minor-patch|dev-all)
-                  allow=true
-                  reason="dependency-group:$DEPENDENCY_GROUP"
-                  ;;
-                *)
-                  title="$(gh pr view "$PR" --json title -q .title)"
-                  # Match "from [>=~^]*X.Y.Z to [>=~^]*A.B.C", ignoring trailing " in /dir".
-                  if [[ "$title" =~ from[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+)[^[:space:]]*[[:space:]]+to[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+) ]]; then
-                    from_major="${BASH_REMATCH[1]}"
-                    to_major="${BASH_REMATCH[3]}"
-                    if [[ "$from_major" == "$to_major" ]]; then
-                      allow=true
-                      reason="title-non-major:$from_major->$to_major"
-                    else
-                      reason="title-major:$from_major->$to_major"
-                    fi
+              # Empty/unknown: only trust groups that exclude majors. `dev-all`
+              # includes majors, so never short-circuit on that group name —
+              # fall through to title parsing instead.
+              if [[ "$DEPENDENCY_GROUP" == "prod-minor-patch" ]]; then
+                allow=true
+                reason="dependency-group:$DEPENDENCY_GROUP"
+              else
+                title="$(gh pr view "$PR" --json title -q .title)"
+                # Match "from [>=~^]*X.Y.Z to [>=~^]*A.B.C", ignoring trailing " in /dir".
+                if [[ "$title" =~ from[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+)[^[:space:]]*[[:space:]]+to[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+) ]]; then
+                  from_major="${BASH_REMATCH[1]}"
+                  to_major="${BASH_REMATCH[3]}"
+                  if [[ "$from_major" == "$to_major" ]]; then
+                    allow=true
+                    reason="title-non-major:$from_major->$to_major"
                   else
-                    reason="unclassified-update-type"
+                    reason="title-major:$from_major->$to_major"
                   fi
-                  ;;
-              esac
+                else
+                  reason="unclassified-update-type"
+                fi
+              fi
               ;;
           esac
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,24 +26,23 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+      # v3.1.0+ restores update-type for pip/composer requirement bumps (no custom title parsing).
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: meta
         with:
           # Branch updates add non-Dependabot merge commits; still parse Dependabot metadata.
           skip-commit-verification: true
 
-      # Decide eligibility without checking out PR code (GitHub API only).
-      # fetch-metadata often leaves update-type empty for pip requirement-range bumps
-      # ("Update X from >=a to >=b in /dir"). Fall back to prod-minor-patch group
-      # membership, otherwise same-major title parsing. Never short-circuit on
-      # dev-all (that group includes majors).
+      # Eligibility uses only fetch-metadata outputs (no PR code checkout, no title parsing):
+      # 1. Block explicit majors
+      # 2. Allow explicit minor/patch
+      # 3. If update-type is empty: allow only groups that exclude majors
+      # 4. Otherwise fail closed
       - name: Determine eligibility
         id: eligible
         env:
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
           DEPENDENCY_GROUP: ${{ steps.meta.outputs.dependency-group }}
-          PR: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -59,28 +58,15 @@ jobs:
               reason="update-type:$UPDATE_TYPE"
               ;;
             *)
-              # Empty/unknown: only trust groups that exclude majors. `dev-all`
-              # includes majors, so never short-circuit on that group name —
-              # fall through to title parsing instead.
-              if [[ "$DEPENDENCY_GROUP" == "prod-minor-patch" ]]; then
-                allow=true
-                reason="dependency-group:$DEPENDENCY_GROUP"
-              else
-                title="$(gh pr view "$PR" --json title -q .title)"
-                # Match "from [>=~^]*X.Y.Z to [>=~^]*A.B.C", ignoring trailing " in /dir".
-                if [[ "$title" =~ from[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+)[^[:space:]]*[[:space:]]+to[[:space:]]+[^0-9v]*([0-9]+)\.([0-9]+) ]]; then
-                  from_major="${BASH_REMATCH[1]}"
-                  to_major="${BASH_REMATCH[3]}"
-                  if [[ "$from_major" == "$to_major" ]]; then
-                    allow=true
-                    reason="title-non-major:$from_major->$to_major"
-                  else
-                    reason="title-major:$from_major->$to_major"
-                  fi
-                else
+              case "$DEPENDENCY_GROUP" in
+                prod-minor-patch|dev-minor-patch)
+                  allow=true
+                  reason="dependency-group:$DEPENDENCY_GROUP"
+                  ;;
+                *)
                   reason="unclassified-update-type"
-                fi
-              fi
+                  ;;
+              esac
               ;;
           esac
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Stopped after Dependabot [#41](https://github.com/proxymesh/proxy-examples/pull/41) (scrapy): CI was green and auto-merge was already enabled, but the approve step never ran because `dependabot/fetch-metadata` v2.5.0 left `update-type` empty for pip requirement-range bumps.

## Fix
No custom title parsing and no PR code checkout.

1. **Bump `dependabot/fetch-metadata` to v3.1.0** — upstream restores `update-type` for pip/composer requirement bumps (`in /dir` regex + title fallback inside the action).
2. **Split Dependabot groups** — replace `dev-all` with:
   - `dev-minor-patch` (auto-merge eligible)
   - `dev-major` (manual review)
3. **Eligibility** (metadata / group only):
   - Block explicit `semver-major`
   - Allow explicit minor/patch
   - If `update-type` is empty: allow only `prod-minor-patch` / `dev-minor-patch`
   - Otherwise fail closed

Keeps `skip-commit-verification` so branch updates still work.

## After merge
Resume updating open Dependabot PR branches one at a time.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://proxymesh.slack.com/archives/C0BMTB962RE/p1788473795626639?thread_ts=1788473795.626639&cid=C0BMTB962RE)

<div><a href="https://cursor.com/agents/bc-0bbb48cb-cc5a-588d-8168-da785840c08c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bbb48cb-cc5a-588d-8168-da785840c08c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

