### PR TITLE
Auto-merge all Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 version: 2
 updates:
+  # Grouping reduces PR noise; all version updates (including majors) auto-merge via
+  # .github/workflows/dependabot-auto-merge.yml once required checks pass.
   - package-ecosystem: "npm"
     directory: "/javascript"
     schedule:
@@ -17,7 +19,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      prod-major:
+        dependency-type: "production"
+        update-types:
+          - "major"
       dev-minor-patch:
         dependency-type: "development"
         update-types:
@@ -45,7 +50,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      prod-major:
+        dependency-type: "production"
+        update-types:
+          - "major"
       dev-minor-patch:
         dependency-type: "development"
         update-types:
@@ -73,7 +81,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      prod-major:
+        dependency-type: "production"
+        update-types:
+          - "major"
       dev-minor-patch:
         dependency-type: "development"
         update-types:
@@ -101,7 +112,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      # Majors stay out of auto-merge groups so group membership alone is a safe signal.
+      prod-major:
+        dependency-type: "production"
+        update-types:
+          - "major"
       dev-minor-patch:
         dependency-type: "development"
         update-types:
@@ -117,6 +131,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    labels:
+      - "dependencies"
+      - "automerge"
     groups:
       actions:
         patterns:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,7 +5,7 @@
 # - Branch protection required status checks (reviews are satisfied by this workflow)
 # See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
 #
-# Major version updates are left for human review (matches Dependabot grouping policy).
+# All Dependabot version updates (including majors) are auto-approved and auto-merged.
 
 name: dependabot-auto-merge
 
@@ -20,61 +20,13 @@ permissions:
 jobs:
   automerge:
     # Same-repo Dependabot PRs only. Key off the PR author so synchronize events from
-    # branch updates (non-Dependabot merge commits) still run.
+    # branch updates (non-Dependabot merge commits) still run. Never check out PR code.
     if: >
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      # v3.1.0+ restores update-type for pip/composer requirement bumps (no custom title parsing).
-      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        id: meta
-        with:
-          # Branch updates add non-Dependabot merge commits; still parse Dependabot metadata.
-          skip-commit-verification: true
-
-      # Eligibility uses only fetch-metadata outputs (no PR code checkout, no title parsing):
-      # 1. Block explicit majors
-      # 2. Allow explicit minor/patch
-      # 3. If update-type is empty: allow only groups that exclude majors
-      # 4. Otherwise fail closed
-      - name: Determine eligibility
-        id: eligible
-        env:
-          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
-          DEPENDENCY_GROUP: ${{ steps.meta.outputs.dependency-group }}
-        run: |
-          set -euo pipefail
-
-          allow=false
-          reason="blocked"
-
-          case "$UPDATE_TYPE" in
-            version-update:semver-major)
-              reason="major-update-type"
-              ;;
-            version-update:semver-minor|version-update:semver-patch)
-              allow=true
-              reason="update-type:$UPDATE_TYPE"
-              ;;
-            *)
-              case "$DEPENDENCY_GROUP" in
-                prod-minor-patch|dev-minor-patch)
-                  allow=true
-                  reason="dependency-group:$DEPENDENCY_GROUP"
-                  ;;
-                *)
-                  reason="unclassified-update-type"
-                  ;;
-              esac
-              ;;
-          esac
-
-          echo "eligibility allow=$allow reason=$reason update_type=${UPDATE_TYPE:-<empty>} group=${DEPENDENCY_GROUP:-<empty>}"
-          echo "allow=$allow" >> "$GITHUB_OUTPUT"
-
       - name: Approve pull request
-        if: steps.eligible.outputs.allow == 'true'
         run: |
           set -euo pipefail
           if [ "$(gh pr view "$PR" --json reviewDecision -q .reviewDecision)" != "APPROVED" ]; then
@@ -85,7 +37,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.eligible.outputs.allow == 'true'
         run: |
           set -euo pipefail
           if [ "$(gh pr view "$PR" --json autoMergeRequest -q '.autoMergeRequest != null')" != "true" ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Auto-approve and enable squash auto-merge for **all** same-repo Dependabot PRs (including majors), once required checks pass
- Remove `fetch-metadata` / update-type eligibility gating — Dependabot author + same-repo head check is enough; workflow still never checks out PR code
- Group production majors (`prod-major`) alongside existing groups to cut PR noise; add `automerge` labels to the github-actions ecosystem

## After merge
Refresh open major Dependabot branches (#40, #48–#51, #55) so they pick up the new workflow and auto-merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://proxymesh.slack.com/archives/C0BMTB962RE/p1788473795626639?thread_ts=1788473795.626639&cid=C0BMTB962RE)

<div><a href="https://cursor.com/agents/bc-b9ee4c11-88c7-5cd4-8732-10776076bef0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9ee4c11-88c7-5cd4-8732-10776076bef0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

