### PR TITLE
fix Dependabot alerts for qs and json

### DIFF
--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -17,7 +17,6 @@
         "make-fetch-happen": "^16.0.1",
         "needle": "^3.5.0",
         "node-fetch": "^3.3.0",
-        "nvm": "^0.0.4",
         "playwright": "^1.62.1",
         "puppeteer": "^25.9.0",
         "socks-proxy-agent": "^10.1.0",
@@ -1561,16 +1560,6 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/nvm": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/nvm/-/nvm-0.0.4.tgz",
-      "integrity": "sha512-jvmyELykYcdyd0VCGY0E8Aqe5MngEasVvlPvrcJHbwBMUbVqa72mPdQuPzyTcykEtEx7jDrMY0QA5MoV+8EhgA==",
-      "deprecated": "This is NOT the correct nvm. Visit https://nvm.sh and use the curl command to install it.",
-      "license": "http://wtfpl.org/",
-      "bin": {
-        "nvm": "bin/nvm"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -2071,22 +2060,6 @@
       },
       "engines": {
         "node": ">= 20.0.0"
-      }
-    },
-    "node_modules/typed-rest-client/node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/uint8array-extras": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -19,7 +19,6 @@
     "make-fetch-happen": "^16.0.1",
     "needle": "^3.5.0",
     "node-fetch": "^3.3.0",
-    "nvm": "^0.0.4",
     "playwright": "^1.62.1",
     "puppeteer": "^25.9.0",
     "socks-proxy-agent": "^10.1.0",
@@ -27,6 +26,9 @@
     "typed-rest-client": "^3.1.0",
     "undici": "^8.10.1",
     "wretch": "^3.0.9"
+  },
+  "overrides": {
+    "qs": "^6.16.0"
   },
   "keywords": [
     "proxy",

--- a/javascript/wretch-proxy.js
+++ b/javascript/wretch-proxy.js
@@ -6,7 +6,7 @@
  *     PROXY_URL       - Proxy URL (required), e.g., http://user:pass@proxy:8080
  *     TEST_URL        - URL to request (default: https://api.ipify.org?format=json)
  *
- * Registers node-fetch + HttpsProxyAgent as wretch’s fetch polyfill for Node.
+ * Registers node-fetch + HttpsProxyAgent via wretch’s per-instance fetchPolyfill (wretch 3).
  */
 import wretch from 'wretch';
 import fetch from 'node-fetch';
@@ -35,10 +35,11 @@ function boundFetch(input, init = {}) {
     return fetch(input, { ...init, agent });
 }
 
-wretch.polyfills({ fetch: boundFetch });
-
 try {
-    const response = await wretch(testUrl).get().res();
+    const response = await wretch(testUrl)
+        .fetchPolyfill(boundFetch)
+        .get()
+        .res();
     const body = await response.text();
 
     console.log(`Status: ${response.status}`);

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       multi_xml (>= 0.5.2)
     httpclient (2.9.0)
       mutex_m
-    json (2.21.1)
+    json (2.21.2)
     llhttp (0.6.2)
     logger (1.7.0)
     mechanize (2.14.1)
@@ -143,7 +143,7 @@ CHECKSUMS
   http-cookie (1.1.6) sha256=ba4b82be64de61dc281243dac70e3c382c45142f20268ed9276a3670c93feaa9
   httparty (0.24.2) sha256=8fca6a54aa0c4aa4303a0fd33e5e2156175d6a5334f714263b458abd7fda9c38
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   llhttp (0.6.2) sha256=3c3c59aafb1e1594ab2f45293478f697458f5a91eb0f0db4b27f61a064024982
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mechanize (2.14.1) sha256=b66205133a01d3dc3bc0cbc5e99888e5476818398d8d315193429f21488abafd


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Clears the 3 open Dependabot alerts in proxy-examples.

## Changes
- **npm:** add `overrides` so nested `qs` from `typed-rest-client` resolves to `^6.16.0` (fixes GHSA-x5fp-wj9c-mxmx and GHSA-4mjr-xmp4-gh2g); remove unused deprecated `nvm` package
- **Ruby:** bump transitive `json` `2.21.1` → `2.21.2` (fixes GHSA-9hj4-r449-hfvc)
- **JS:** update `wretch-proxy.js` for wretch 3 (`fetchPolyfill` instead of removed `polyfills`) so integration CI passes after the earlier major bump

`npm audit` reports 0 vulnerabilities afterward.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://proxymesh.slack.com/archives/C0BMTB962RE/p1788561385104739?thread_ts=1788561385.104739&cid=C0BMTB962RE)

<div><a href="https://cursor.com/agents/bc-382bbd4b-5b4d-5007-9e66-79f69be5774f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-382bbd4b-5b4d-5007-9e66-79f69be5774f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

